### PR TITLE
Assert: Drop 'assertion' from short descriptions

### DIFF
--- a/entries/deepEqual.xml
+++ b/entries/deepEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A deep recursive comparison assertion, working on primitive types, arrays, objects, regular expressions, dates and functions.
+		A deep recursive comparison, working on primitive types, arrays, objects, regular expressions, dates and functions.
 	</desc>
 	<longdesc>
 		<p>The <code>deepEqual()</code> assertion can be used just like <code>equal()</code> when comparing the value of objects, such that <code>{ key: value }</code> is equal to <code>{ key: value }</code>. For non-scalar values, identity will be disregarded by <code>deepEqual</code>.</p>

--- a/entries/equal.xml
+++ b/entries/equal.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A non-strict comparison assertion, roughly equivalent to JUnit <code>assertEquals</code>.
+		A non-strict comparison, roughly equivalent to JUnit's <code>assertEquals</code>.
 	</desc>
 	<longdesc>
 		<p>The <code>equal</code> assertion uses the simple comparison operator (<code>==</code>) to compare the actual and expected arguments. When they are equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.</p>

--- a/entries/notDeepEqual.xml
+++ b/entries/notDeepEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		An inverted deep recursive comparison assertion, working on primitive types, arrays, objects, regular expressions, dates and functions.
+		An inverted deep recursive comparison, working on primitive types, arrays, objects, regular expressions, dates and functions.
 	</desc>
 	<longdesc>
 		<p>The <code>notDeepEqual()</code> assertion can be used just like <code>equal()</code> when comparing the value of objects, such that <code>{ key: value }</code> is equal to <code>{ key: value }</code>. For non-scalar values, identity will be disregarded by <code>notDeepEqual</code>.</p>

--- a/entries/notEqual.xml
+++ b/entries/notEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A non-strict comparison assertion, checking for inequality.
+		A non-strict comparison, checking for inequality.
 	</desc>
 	<longdesc>
 		<p>The <code>notEqual</code> assertion uses the simple inverted comparison operator (<code>!=</code>) to compare the actual and expected arguments. When they aren't equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.</p>

--- a/entries/notPropEqual.xml
+++ b/entries/notPropEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A strict comparison of an object own properties assertion, checking for inequality.
+		A strict comparison of an object's own properties, checking for inequality.
 	</desc>
 	<longdesc>
 		<p>The <code>notPropEqual</code> assertion uses the strict inverted comparison operator (<code>!==</code>) to compare the actual and expected arguments as Objects regarding only their properties but not their constructors.</p>

--- a/entries/notStrictEqual.xml
+++ b/entries/notStrictEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A strict comparison assertion, checking for inequality.
+		A strict comparison, checking for inequality.
 	</desc>
 	<longdesc>
 		<p>The <code>notStrictEqual</code> assertion uses the strict inverted comparison operator (<code>!==</code>) to compare the actual and expected arguments. When they aren't equal, the assertion passes; otherwise, it fails. When it fails, both actual and expected values are displayed in the test result, in addition to a given message.</p>

--- a/entries/ok.xml
+++ b/entries/ok.xml
@@ -11,7 +11,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A boolean assertion, equivalent to CommonJS's assert.ok() and JUnit's assertTrue(). Passes if the first argument is truthy.
+		A boolean check, equivalent to CommonJS's assert.ok() and JUnit's assertTrue(). Passes if the first argument is truthy.
 	</desc>
 	<longdesc>
 		<p>The most basic assertion in QUnit, <code>ok()</code> requires just one argument. If the argument evaluates to true, the assertion passes; otherwise, it fails. If a second message argument is provided, it will be displayed in place of the result.</p>

--- a/entries/propEqual.xml
+++ b/entries/propEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A strict type and value comparison of an object own properties assertion.
+		A strict type and value comparison of an object's own properties.
 	</desc>
 	<longdesc>
 		<p>The <code>propEqual()</code> assertion provides strictly (<code>===</code>) comparison of Object properties. Unline <code>deepEqual()</code>, this assertion can be used to compare two objects made with different constructors and prototype.</p>

--- a/entries/strictEqual.xml
+++ b/entries/strictEqual.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		A strict type and value comparison assertion.
+		A strict type and value comparison.
 	</desc>
 	<longdesc>
 		<p>The <code>strictEqual()</code> assertion provides the most rigid comparison of type and value with the strict equality operator (<code>===</code>).</p>

--- a/entries/throws.xml
+++ b/entries/throws.xml
@@ -14,7 +14,7 @@
 		</argument>
 	</signature>
 	<desc>
-		Assertion to test if a callback throws an exception when run.
+		Test if a callback throws an exception, and optionally compare the thrown error.
 	</desc>
 	<longdesc>
 		<p>When testing code that is expected to throw an exception based on a specific set of circumstances, use <code>throws()</code> to catch the error object for testing and comparison.</p>


### PR DESCRIPTION
Having 'assertion' in each description doesn't read well and isn't necessary anyway, since the context should be obivious enough.
