### PR TITLE
Expect: Remove parameter example

### DIFF
--- a/entries/QUnit.push.xml
+++ b/entries/QUnit.push.xml
@@ -32,7 +32,7 @@ QUnit.assert.mod2 = function( value, expected, message ) {
 	var actual = value % 2;
 	QUnit.push( actual === expected, actual, expected, message );
 };
-test( "mod2", 2, function( assert ) {
+test( "mod2", function( assert ) {
 	assert.mod2( 2, 0, "2 % 2 == 0" );
 	assert.mod2( 3, 1, "3 % 2 == 1" );
 });

--- a/entries/expect.xml
+++ b/entries/expect.xml
@@ -32,24 +32,5 @@ test( "a test", function() {
 });
 ]]></code>
 	</example>
-	<example height="250">
-		<desc>expectation count can be passed as the second parameter to <code>test()</code> or <code>asyncTest()</code>:</desc>
-<code><![CDATA[
-test( "a test", 2, function() {
-
-	function calc( x, operation ) {
-		return operation( x );
-	}
-
-	var result = calc( 2, function( x ) {
-		ok( true, "calc() calls operation function" );
-		return x * x;
-	});
-
-	equal( result, 4, "2 squared equals 4" );
-});
-]]></code>
-	</example>
-
 	<category slug="test"/>
 </entry>


### PR DESCRIPTION
It's deprecated and no longer recommended for using.

I can also merge it with #49, but it's specific enough that I preferred to keep it in another commit/pr.
