### PR TITLE
Assert: Document assert.push

### DIFF
--- a/entries/QUnit.push.xml
+++ b/entries/QUnit.push.xml
@@ -28,18 +28,5 @@
 			Invoking <code>QUnit.push</code> allows to create a readable expectation that is not defined by any of QUnit's built-in assertions.
 		</p>
 	</longdesc>
-	<example>
-		<desc>Define a custom <code>mod2</code> assertion that tests if the provided numbers are equivalent in modulo 2.</desc>
-		<code><![CDATA[
-QUnit.assert.mod2 = function( value, expected, message ) {
-	var actual = value % 2;
-	QUnit.push( actual === expected, actual, expected, message );
-};
-QUnit.test( "mod2", function( assert ) {
-	assert.mod2( 2, 0, "2 % 2 == 0" );
-	assert.mod2( 3, 1, "3 % 2 == 1" );
-});
-]]></code>
-	</example>
 	<category slug="config"/>
 </entry>

--- a/entries/push.xml
+++ b/entries/push.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="../entries2html.xsl" ?>
+<entry type="method" name="push">
+    <title>push()</title>
+    <signature>
+        <argument name="result" type="Boolean">
+            <desc>Result of the assertion</desc>
+        </argument>
+        <argument name="actual" type="Object">
+            <desc>Expression being tested</desc>
+        </argument>
+        <argument name="expected" type="Object">
+            <desc>Known comparison value</desc>
+        </argument>
+        <argument name="message" type="String">
+            <desc>A short description of the assertion</desc>
+        </argument>
+    </signature>
+    <desc>
+        Report the result of a custom assertion
+    </desc>
+    <longdesc>
+        <p>
+            Some test suites may need to express an expectation that is not defined by any of QUnit's built-in assertions. This need may be met by encapsulating the expectation in a JavaScript function which returns a <code>Boolean</code> value representing the result; this value can then be passed into QUnit's <code>ok</code> assertion.
+        </p>
+        <p>
+            A more readable solution would involve defining a custom assertion. If the expectation function invokes <code>push</code>, QUnit will be notified of the result and report it accordingly.
+        </p>
+    </longdesc>
+    <example>
+        <desc>Define a custom <code>mod2</code> assertion that tests if the provided numbers are equivalent in modulo 2.</desc>
+<code><![CDATA[
+QUnit.assert.mod2 = function( value, expected, message ) {
+    var actual = value % 2;
+    this.push( actual === expected, actual, expected, message );
+};
+
+QUnit.test( "mod2", function( assert ) {
+    assert.expect( 2 );
+
+    assert.mod2( 2, 0, "2 % 2 == 0" );
+    assert.mod2( 3, 1, "3 % 2 == 1" );
+});
+]]></code>
+    </example>
+    <category slug="assert"/>
+</entry>


### PR DESCRIPTION
Also notify of QUnit.push deprecation.

Ref: jquery/qunit#588

This can be improved, but I need some help here.

I'm also trying to test this on jquery-wp-content but some issue is preventing me to build the html files there. 
