### PR TITLE
Module: Fix test env usage example

### DIFF
--- a/entries/QUnit.module.xml
+++ b/entries/QUnit.module.xml
@@ -64,20 +64,20 @@ QUnit.module( "module A", {
 		<desc>Lifecycle properties are shared on respective test context</desc>
 <code><![CDATA[
 QUnit.module( "Machine Maker", {
-    setup: function() {
-        this.maker = new Maker();
-    },
-    parts: [ "wheels", "motor", "chassis" ]
+	setup: function() {
+		this.maker = new Maker();
+		this.parts = [ "wheels", "motor", "chassis" ];
+	}
 });
 
 QUnit.test( "makes a robot", function( assert ) {
 	this.parts.push( "arduino" );
-	assert.equal( this.maker( this.parts ), "robot" );
+	assert.equal( this.maker.build( this.parts ), "robot" );
 	assert.deepEqual( this.maker.made, [ "robot" ] );
 });
 
 QUnit.test( "makes a car", function( assert ) {
-	assert.equal( this.maker( this.parts ), "car" );
+	assert.equal( this.maker.build( this.parts ), "car" );
 	this.maker.duplicate();
 	assert.deepEqual( this.maker.made, [ "car", "car" ] );
 });


### PR DESCRIPTION
Fixes the indentation issue in the module call, and assumes that Maker is a constructor with a build method, which the tests then call.

Also, in the QUnit issue itself I suggested to fix this by deep-copying the test environment properties. I've looked into that and concluded that its way too complicated for something that no one ever had a problem with, as far as I can tell. Instead we can just fix the example to use a new parts array for each test.

Fixes #90
Fixes jquery/qunit#688
