### PR TITLE
Fix copy-paste error for testDone

### DIFF
--- a/entries/QUnit.testDone.xml
+++ b/entries/QUnit.testDone.xml
@@ -9,7 +9,7 @@
 				<argument name="details" type="Object"/>
 			</type>
 			<property name="name" type="String">
-				<desc>Name of the next test to run</desc>
+				<desc>Name of the current test</desc>
 			</property>
 			<property name="module" type="String">
 				<desc>Name of the current module</desc>


### PR DESCRIPTION
The current docs suggest that testDone returns the name of the *next* test to run. I believe this is a copy-paste error and should be the name of the test that has been run?