### PR TITLE
Build: move redirects from infrastructure repo to `redirects.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "grunt": "0.4.5",
-    "grunt-jquery-content": "2.0.0"
+    "grunt-jquery-content": "2.3.0"
   }
 }

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,9 @@
+{
+	"/api/": "/resources/api.xml",
+	"/asyncTest/": "/QUnit.asyncTest/",
+	"/module/": "/QUnit.module/",
+	"/start/": "/QUnit.start/",
+	"/stop/": "/QUnit.stop/",
+	"/test/": "/QUnit.test/",
+	"/QUnit.jsDump.parse/": "/QUnit.dump.parse/"
+}


### PR DESCRIPTION
Moved the redirects from the infrastructure repo to the `redirects.json` file (a new feature introduced in grunt-jquery-content 2.3.0)

Infrastructure link: https://github.com/jquery/infrastructure/blob/puppet-master/modules/jquery/manifests/wp/qunitjs.pp#L19-26. I'm going to do an infra PR too. Do we prefer one big infrastructure PR when all redirects are done, or one per website we update?

@gnarf Would be cool if you could review this :) Thanks! 
