### PR TITLE
Entries: Ensure paragraphs have proper tags in QUnit.config

### DIFF
--- a/entries/QUnit.config.xml
+++ b/entries/QUnit.config.xml
@@ -5,79 +5,79 @@
 	<signature>
 		<property name="altertitle" type="Boolean" default="true">
 			<desc>
-				By default, QUnit updates document.title to add a checkmark or x-mark to indicate if a testsuite passed or failed. This makes it easy to see a suites result even without looking at a tab's content.
+				<p>By default, QUnit updates document.title to add a checkmark or x-mark to indicate if a testsuite passed or failed. This makes it easy to see a suites result even without looking at a tab's content.</p>
 				<p>If you're dealing with code that tests <code>document.title</code> changes or have some other problem with this feature, set this option to false to disable it.</p>
 			</desc>
 		</property>
 		<property name="autostart" type="Boolean" default="true">
 			<desc>
-				By default, QUnit runs tests when <code>load</code> event is triggered on the <code>window</code>. If you're loading tests asynchronously, you can set this property to <code>false</code>, then call <code>QUnit.start()</code> once everything is loaded. See below for an example.
+				<p>By default, QUnit runs tests when <code>load</code> event is triggered on the <code>window</code>. If you're loading tests asynchronously, you can set this property to <code>false</code>, then call <code>QUnit.start()</code> once everything is loaded. See below for an example.</p>
 			</desc>
 		</property>
 		<property name="collapse" type="Boolean" default="true">
 			<desc>
-				By default, QUnit's HTML reporter collapses consecutive failing tests showing only the details for the first failed test. The other tests can be expanded manually with a single click on the test title. Setting this value to <code>false</code> will expand the details for every failing test.
+				<p>By default, QUnit's HTML reporter collapses consecutive failing tests showing only the details for the first failed test. The other tests can be expanded manually with a single click on the test title. Setting this value to <code>false</code> will expand the details for every failing test.</p>
 			</desc>
 		</property>
 		<property name="current" type="Object">
 			<desc>
-				This object isn't actually a configuration property, but is listed here anyway, as its exported through <code>QUnit.config</code>. This gives you access to some QUnit internals at runtime. See below for an example.
+				<p>This object isn't actually a configuration property, but is listed here anyway, as its exported through <code>QUnit.config</code>. This gives you access to some QUnit internals at runtime. See below for an example.</p>
 			</desc>
 		</property>
 		<property name="hidepassed" type="Boolean" default="false">
 			<desc>
-				By default, the HTML Reporter will show all the tests results. Enabling this option will make it show only the failing tests, hiding all that pass. This can also be managed by the HTML interface.
+				<p>By default, the HTML Reporter will show all the tests results. Enabling this option will make it show only the failing tests, hiding all that pass. This can also be managed by the HTML interface.</p>
 			</desc>
 		</property>
 		<property name="module" type="String" default="undefined">
 			<desc>
-				Specify a single module to run by name (exact case-insensitive match required). By default, QUnit will run all the loaded modules when this property is not specified.
+				<p>Specify a single module to run by name (exact case-insensitive match required). By default, QUnit will run all the loaded modules when this property is not specified.</p>
 				<p>This property was absent in versions 1.16.0 through 1.22.0.</p>
 			</desc>
 		</property>
 		<property name="moduleId" type="Array" default="undefined">
 			<desc>
-				This property allows QUnit to run specific modules identified by the hashed version of their module name. You can specify one or multiple modules to run.
+				<p>This property allows QUnit to run specific modules identified by the hashed version of their module name. You can specify one or multiple modules to run.</p>
 			</desc>
 		</property>
 		<property name="seed" type="String" default="undefined">
 			<desc>
-				This property tells QUnit to run tests in a seeded-random order. The value provided will be used as the seed in a pseudo-random number generator to ensure that results are reproducible. The randomization will also respect the `reorder` option if enabled and re-run failed tests first without randomizing them.
+				<p>This property tells QUnit to run tests in a seeded-random order. The value provided will be used as the seed in a pseudo-random number generator to ensure that results are reproducible. The randomization will also respect the `reorder` option if enabled and re-run failed tests first without randomizing them.</p>
 				<p>Randomly ordering your tests can help identify non-atomic tests which either depend on a previous test or are leaking state to following tests. This is particularly beneficial in a development CI or post-commit process.</p>
 				<p>If <code>seed</code> is specified in the page's url parameters, but no value is specified, then QUnit will generate a random value to use as the seed. You can access the value from this property and use it to repeat the same sequence in another run.</p>
 			</desc>
 		</property>
 		<property name="reorder" type="Boolean" default="true">
 			<desc>
-				By default, QUnit will run tests first that failed on a previous run. In a large testsuite, this can speed up testing a lot.
+				<p>By default, QUnit will run tests first that failed on a previous run. In a large testsuite, this can speed up testing a lot.</p>
 				<p>It can also lead to random errors, in case your testsuite has non-atomic tests, where the order is important. You should fix those issues, instead of disabling reordering!</p>
 				<p>When a failed test is running first, <code>Rerunning previously failed test</code> is displayed in the summary whereas just <code>Running</code> is displayed otherwise.</p>
 			</desc>
 		</property>
 		<property name="requireExpects" type="Boolean" default="false">
 			<desc>
-				The <code>expect()</code> method is optional by default, though it can be useful to require each test to specify the number of expected assertions.
+				<p>The <code>expect()</code> method is optional by default, though it can be useful to require each test to specify the number of expected assertions.</p>
 				<p>Enabling this option will cause tests to fail, if they don't call <code>expect()</code> at all.</p>
 			</desc>
 		</property>
 		<property name="testId" type="Array" default="undefined">
 			<desc>
-				This property allows QUnit to run specific tests identified by the hashed version of their module name and test name. You can specify one or multiple tests to run.
+				<p>This property allows QUnit to run specific tests identified by the hashed version of their module name and test name. You can specify one or multiple tests to run.</p>
 			</desc>
 		</property>
 		<property name="testTimeout" type="Number" default="undefined">
 			<desc>
-				Specify a global timeout in milliseconds after which all tests will fail with an appropriate message. Useful when async tests aren't finishing, to prevent the testrunner getting stuck. Set to something high, e.g. 30000 (30 seconds) to avoid slow tests to time out by accident.
+				<p>Specify a global timeout in milliseconds after which all tests will fail with an appropriate message. Useful when async tests aren't finishing, to prevent the testrunner getting stuck. Set to something high, e.g. 30000 (30 seconds) to avoid slow tests to time out by accident.</p>
 			</desc>
 		</property>
 		<property name="scrolltop" type="Boolean" default="true">
 			<desc>
-				By default, scroll to top of the page when suite is done. Setting this to false will leave the page scroll alone.
+				<p>By default, scroll to top of the page when suite is done. Setting this to false will leave the page scroll alone.</p>
 			</desc>
 		</property>
 		<property name="urlConfig" type="Array">
 			<desc>
-				This property controls which form controls to put into the QUnit toolbar element (below the header). By default, the "noglobals" and "notrycatch" checkboxes are there. By extending this array, you can add your own checkboxes and select lists.
+				<p>This property controls which form controls to put into the QUnit toolbar element (below the header). By default, the "noglobals" and "notrycatch" checkboxes are there. By extending this array, you can add your own checkboxes and select lists.</p>
 				<p>Each element should be an object with an <code>id</code> property (used as the config and query-string key) and a <code>label</code> property (used as text in the UI), and optionally a <code>tooltip</code> property (used as the 	title attribute to explain what the control does). Each element should also have a <code>value</code> property controlling available options and rendering.</p>
 				<p>If <code>value</code> is undefined, the option will render as a checkbox. The corresponding URL parameter will be set to "true" when the checkbox is checked, and otherwise will be absent.</p>
 				<p>If <code>value</code> is a string, the option will render as a checkbox. The corresponding URL parameter will be set to the string when the checkbox is checked, and otherwise will be absent.</p>


### PR DESCRIPTION
Noticed during #128 that most of the property descriptions didn't have proper tags around their first paragraphs. Not sure if that was intentional, but it makes the spacing inconsistent and is semantically incorrect.